### PR TITLE
two small fixes

### DIFF
--- a/examples/jsm/loaders/3DMLoader.d.ts
+++ b/examples/jsm/loaders/3DMLoader.d.ts
@@ -9,6 +9,7 @@ export class Rhino3dmLoader extends Loader {
 	constructor( manager?: LoadingManager );
 
 	load( url: string, onLoad: ( object: Object3D ) => void, onProgress?: ( event: ProgressEvent ) => void, onError?: ( event: ErrorEvent ) => void ): void;
+	parse( data: ArrayBufferLike, onLoad: ( object: Object3D ) => void, onError?: ( event: ErrorEvent ) => void ): void;
 	setLibraryPath( path: string ): Rhino3dmLoader;
 	setWorkerLimit( workerLimit: number ): Rhino3dmLoader;
 	dispose(): Rhino3dmLoader;

--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -278,7 +278,9 @@ Rhino3dmLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 					}
 
-					_object.visible = data.layers[ attributes.layerIndex ].visible;
+					var layer = data.layers[ attributes.layerIndex ]
+					
+					_object.visible = layer ? data.layers[ attributes.layerIndex ].visible : true;
 
 					if ( attributes.isInstanceDefinitionObject ) {
 


### PR DESCRIPTION
Bubbling up two minor things I encountered working with the loader for the first time:

- The type for the `.parse()` method was missing.
- I was creating empty `File3dm` objects, adding geometry, and passing it to the loader. Since there were no layers, `_createGeometry()` was throwing an error. I added a fallback for the visibility check.